### PR TITLE
fix watch_default_branch

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -73,7 +73,7 @@ export const MergerBot: ApplicationFunction = (app: Application) => {
     const config = (await loadConfig(context)) as Config
     if (!config.enabled || !config.watch_default_branch) return
     const defaultBranch = context.payload.repository.default_branch
-    if (context.payload.ref !== `refs/${defaultBranch}` || context.payload.ref !== `refs/head/${defaultBranch}`) return
+    if (context.payload.ref !== `refs/${defaultBranch}` && context.payload.ref !== `refs/heads/${defaultBranch}`) return
     app.log.debug(`attempting to merge ${defaultBranch} into staging`)
     await mergeIntoStaging(context, defaultBranch)
   })

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -73,7 +73,7 @@ export const MergerBot: ApplicationFunction = (app: Application) => {
     const config = (await loadConfig(context)) as Config
     if (!config.enabled || !config.watch_default_branch) return
     const defaultBranch = context.payload.repository.default_branch
-    if (context.payload.ref !== `refs/${defaultBranch}`) return
+    if (context.payload.ref !== `refs/${defaultBranch}` || context.payload.ref !== `refs/head/${defaultBranch}`) return
     app.log.debug(`attempting to merge ${defaultBranch} into staging`)
     await mergeIntoStaging(context, defaultBranch)
   })

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -129,7 +129,7 @@ describe('Staging Merger Bot', () => {
         .post('/repos/soberstadt/test-merge-repo/merges', (body) => {
           expect(body).toMatchObject({
             base: 'staging',
-            head: 'heads/main'
+            head: 'main'
           })
           return true
         })

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -129,7 +129,7 @@ describe('Staging Merger Bot', () => {
         .post('/repos/soberstadt/test-merge-repo/merges', (body) => {
           expect(body).toMatchObject({
             base: 'staging',
-            head: 'main'
+            head: 'head/main'
           })
           return true
         })

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -129,7 +129,7 @@ describe('Staging Merger Bot', () => {
         .post('/repos/soberstadt/test-merge-repo/merges', (body) => {
           expect(body).toMatchObject({
             base: 'staging',
-            head: 'head/main'
+            head: 'heads/main'
           })
           return true
         })

--- a/test/fixtures/push.json
+++ b/test/fixtures/push.json
@@ -1,5 +1,5 @@
 {
-  "ref": "refs/main",
+  "ref": "refs/heads/main",
   "before": "6113728f27ae82c7b1a177c8d03f9e96e0adf246",
   "after": "0000000000000000000000000000000000000000",
   "created": false,


### PR DESCRIPTION
 I don't know if this feature was ever actaully tested, but I have tried using it on okta-profile-editor and it hasn't been merging main into staging as I add new commits.

Proof of ref name:
![image](https://user-images.githubusercontent.com/1080613/110968485-957da480-8325-11eb-85b0-9288d5176915.png)
