### PR TITLE
Include PR number in commit message

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -99,15 +99,18 @@ export const MergerBot: ApplicationFunction = (app: Application) => {
   async function mergePRIntoStaging (context: Context, config: Config) {
     app.log.debug(`attempting to merge PR into ${config.base_name}`)
     const { data: prDetails } = await context.github.pulls.get(context.issue())
-    await mergeIntoStaging(context, prDetails.head.ref, config).catch(async error => {
+    await mergeIntoStaging(context, prDetails.head.ref, config, prDetails.number).catch(async error => {
       await mergeError(error, context, config)
     })
   }
 
-  async function mergeIntoStaging (context: Context, head: string, config: Config) {
+  async function mergeIntoStaging (context: Context, head: string, config: Config, prNumber?: number) {
+    const prInfo = prNumber ? ` (PR #${prNumber})` : '';
+    const commitMessage = `Merge branch '${head}'${prInfo} into ${config.base_name}`
     const mergePayload = context.repo({
       base: config.base_name,
-      head: head
+      head: head,
+      commit_message: commitMessage
     })
     await context.github.repos.merge(mergePayload)
   }

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -11,7 +11,8 @@ const issueCreatedBody = {
 }
 const mergeBody = {
   base: 'staging',
-  head: 'asdf1234'
+  head: 'asdf1234',
+  commit_message: "Merge branch 'asdf1234' (PR #2) into staging"
 }
 
 nock.disableNetConnect()
@@ -49,7 +50,7 @@ describe('Staging Merger Bot', () => {
       // allow test to get PR details
       nock('https://api.github.com')
         .get('/repos/soberstadt/test-merge-repo/pulls/2')
-        .reply(200, { head: { ref: 'asdf1234' } })
+        .reply(200, { head: { ref: 'asdf1234' }, number: 2 })
 
       mergeMock = nock('https://api.github.com')
         .post('/repos/soberstadt/test-merge-repo/merges', (body) => {
@@ -89,7 +90,7 @@ describe('Staging Merger Bot', () => {
       // allow test to get PR details
       nock('https://api.github.com')
         .get('/repos/soberstadt/test-merge-repo/pulls/2')
-        .reply(200, { head: { ref: 'asdf1234' } })
+        .reply(200, { head: { ref: 'asdf1234' }, number: 2 })
 
       // allow test to get PR labels
       nock('https://api.github.com')


### PR DESCRIPTION
When going through `git log staging` and trying to figure out which PR various changes came from, it would often be helpful to have easy access to the PR number in addition to the branch name that was merged into staging.

This PR customizes the default commit message to include the PR number in the commit message.

(I'm not sure who maintains this repo, so I'm requesting a review from recent committers)