### PR TITLE
Fix merge conflict detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.0",
       "license": "ISC",
       "dependencies": {
+        "@octokit/request-error": "^7.1.0",
         "probot": "^14.3.2"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@octokit/request-error": "^7.1.0",
     "probot": "^14.3.2"
   },
   "devDependencies": {

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,3 +1,4 @@
+import { RequestError } from '@octokit/request-error'
 import type { ApplicationFunction, Context, Probot } from 'probot'
 
 interface Config {
@@ -99,7 +100,7 @@ export const MergerBot: ApplicationFunction = (app: Probot) => {
     try {
       await mergeIntoStaging(context, prDetails.head.ref, config, prDetails.number)
     } catch (error) {
-      await mergeError(context, config, error as { message: string })
+      await mergeError(context, config, error)
     }
   }
 
@@ -143,18 +144,14 @@ export const MergerBot: ApplicationFunction = (app: Probot) => {
     }
   }
 
-  async function mergeError(
-    context: Context,
-    config: Config,
-    error: { message: string },
-  ): Promise<void> {
-    if (error.message === 'Merge conflict') {
+  async function mergeError(context: Context, config: Config, error: unknown): Promise<void> {
+    if (error instanceof RequestError && error.status === 409) {
       await addComment(
         context,
         `Merge conflict attempting to merge this into ${config.base_name}. Please fix manually.`,
       )
     } else {
-      app.log.error(`issue merging branch: ${error.message}`)
+      app.log.error(`issue merging branch: ${error instanceof Error ? error.message : error}`)
     }
   }
 }

--- a/test/bot.test.ts
+++ b/test/bot.test.ts
@@ -89,6 +89,30 @@ describe('Staging Merger Bot', () => {
       await probot.receive({ id: '1', name: 'pull_request', payload: labeledPayload as never })
       expect(scope.pendingMocks()).toEqual([])
     })
+
+    test('posts a conflict comment when merge returns 409', async () => {
+      const commentBodies: string[] = []
+      const captureComment = (body: { body: string }): boolean => {
+        commentBodies.push(body.body)
+        return true
+      }
+      const scope = mockConfig(nock('https://api.github.com'), baseConfigYaml)
+        .get('/repos/soberstadt/test-merge-repo/pulls/2')
+        .reply(200, { head: { ref: 'test2' }, number: 2 })
+        .post('/repos/soberstadt/test-merge-repo/issues/2/comments', captureComment)
+        .reply(200, {})
+        .post('/repos/soberstadt/test-merge-repo/merges')
+        .reply(409, { message: 'Merge conflict' })
+        .post('/repos/soberstadt/test-merge-repo/issues/2/comments', captureComment)
+        .reply(200, {})
+
+      await probot.receive({ id: '5', name: 'pull_request', payload: labeledPayload as never })
+      expect(scope.pendingMocks()).toEqual([])
+      expect(commentBodies).toEqual([
+        issueCreatedBody.body,
+        'Merge conflict attempting to merge this into staging. Please fix manually.',
+      ])
+    })
   })
 
   describe('on pr sync', () => {

--- a/test/bot.test.ts
+++ b/test/bot.test.ts
@@ -90,29 +90,33 @@ describe('Staging Merger Bot', () => {
       expect(scope.pendingMocks()).toEqual([])
     })
 
-    test('posts a conflict comment when merge returns 409', async () => {
-      const commentBodies: string[] = []
-      const captureComment = (body: { body: string }): boolean => {
-        commentBodies.push(body.body)
-        return true
-      }
-      const scope = mockConfig(nock('https://api.github.com'), baseConfigYaml)
-        .get('/repos/soberstadt/test-merge-repo/pulls/2')
-        .reply(200, { head: { ref: 'test2' }, number: 2 })
-        .post('/repos/soberstadt/test-merge-repo/issues/2/comments', captureComment)
-        .reply(200, {})
-        .post('/repos/soberstadt/test-merge-repo/merges')
-        .reply(409, { message: 'Merge conflict' })
-        .post('/repos/soberstadt/test-merge-repo/issues/2/comments', captureComment)
-        .reply(200, {})
+    test(
+      'posts a conflict comment when merge returns 409',
+      async () => {
+        const commentBodies: string[] = []
+        const captureComment = (body: { body: string }): boolean => {
+          commentBodies.push(body.body)
+          return true
+        }
+        const scope = mockConfig(nock('https://api.github.com'), baseConfigYaml)
+          .get('/repos/soberstadt/test-merge-repo/pulls/2')
+          .reply(200, { head: { ref: 'test2' }, number: 2 })
+          .post('/repos/soberstadt/test-merge-repo/issues/2/comments', captureComment)
+          .reply(200, {})
+          .post('/repos/soberstadt/test-merge-repo/merges')
+          .reply(409, { message: 'Merge conflict' })
+          .post('/repos/soberstadt/test-merge-repo/issues/2/comments', captureComment)
+          .reply(200, {})
 
-      await probot.receive({ id: '5', name: 'pull_request', payload: labeledPayload as never })
-      expect(scope.pendingMocks()).toEqual([])
-      expect(commentBodies).toEqual([
-        issueCreatedBody.body,
-        'Merge conflict attempting to merge this into staging. Please fix manually.',
-      ])
-    })
+        await probot.receive({ id: '5', name: 'pull_request', payload: labeledPayload as never })
+        expect(scope.pendingMocks()).toEqual([])
+        expect(commentBodies).toEqual([
+          issueCreatedBody.body,
+          'Merge conflict attempting to merge this into staging. Please fix manually.',
+        ])
+      },
+      10000,
+    )
   })
 
   describe('on pr sync', () => {


### PR DESCRIPTION
Since the upgrade, the message isn't exactly `"Merge conflict"`, so the merge conflict detection check fails.

Claude's analysis 🤖:

> After the Probot/Octokit upgrade, the bot stopped posting a "merge conflict" comment when a PR couldn't be auto-merged into staging.
> 
> The handler in `src/bot.ts` distinguished merge-conflict errors from other failures by string-matching the error message:
> 
> ```ts
> if (error.message === 'Merge conflict') { ... }
> ```
> 
> This worked against the older Octokit, which set `RequestError.message` to the raw `message` field from the GitHub API response body — exactly `"Merge conflict"` for a 409 on `/repos/{owner}/{repo}/merges`.
> 
> The newer `@octokit/request` (shipped via `probot@14`) builds the error message differently. In `fetch-wrapper.js`:
> 
> ```js
> const suffix = "documentation_url" in data ? ` - ${data.documentation_url}` : "";
> return `${data.message}${suffix}`;
> ```
> 
> GitHub's 409 response includes a `documentation_url`, so `error.message` is now:
> 
> ```
> Merge conflict - https://docs.github.com/rest/branches/branches#merge-a-branch
> ```
> 
> Strict equality fails, the handler falls into the `else` branch, and only logs the error — no comment is posted. The conflict path was not covered by any test, so the regression slipped through the upgrade silently.